### PR TITLE
Change linter to use new gotype "-r" option

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,7 +11,6 @@
 """This module exports the Gotype plugin class."""
 
 from os import path
-from os.path import dirname
 from SublimeLinter.lint import Linter, util
 import re
 
@@ -44,18 +43,15 @@ class Gotype(Linter):
 
         We override this method so that errors not pertaining to the file
         being edited are not returned.
-
         """
-
         match, line, col, error, warning, message, near = super().split_match(match)
 
         filename = path.basename(self.filename)
-        if re.match(self.fileRegex,match.group(0)).group(1) != filename:
+        if re.match(self.fileRegex, match.group(0)).group(1) != filename:
             return None, 0, 0, '', '', '', ''
 
         return match, line, col, error, warning, message, near
 
     def cmd(self):
-        """Generate the linter command string"""
+        """Generate the linter command string."""
         return [self.executable_path, '-e', '-a', '-r='+path.basename(self.filename), '.']
-

--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ from SublimeLinter.lint import Linter, util
 import re
 
 
-class GoType(Linter):
+class Gotype(Linter):
 
     """Provides an interface to gotype."""
 
@@ -26,6 +26,17 @@ class GoType(Linter):
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     fileRegex = r'^(?P<file>[^:]+):.+'
     error_stream = util.STREAM_STDERR
+
+    def __init__(self, view, syntax):
+        """Initialize and load GOPATH from settings if present."""
+        super(Gotype, self).__init__(view, syntax)
+
+        gopath = self.get_view_settings().get('gopath')
+        if gopath:
+            if self.env:
+                self.env['GOPATH'] = gopath
+            else:
+                self.env = {'GOPATH': gopath}
 
     def split_match(self, match):
         """

--- a/linter.py
+++ b/linter.py
@@ -10,24 +10,41 @@
 
 """This module exports the Gotype plugin class."""
 
-from os import listdir
+from os import path
 from os.path import dirname
 from SublimeLinter.lint import Linter, util
+import re
 
 
-class Gotype(Linter):
+class GoType(Linter):
 
     """Provides an interface to gotype."""
 
     syntax = ('go', 'gosublime-go')
-    cmd = ('gotype', '-e', '-a', '.')
+    cmd = None
+    executable = 'gotype'
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
+    fileRegex = r'^(?P<file>[^:]+):.+'
     error_stream = util.STREAM_STDERR
 
-    def __init__(self, view, syntax):
-        """Initialize and load GOPATH from settings if present."""
-        super(Gotype, self).__init__(view, syntax)
+    def split_match(self, match):
+        """
+        Extract and return values from match.
 
+        We override this method so that errors not pertaining to the file
+        being edited are not returned.
+
+        """
+
+        match, line, col, error, warning, message, near = super().split_match(match)
+
+        filename = path.basename(self.filename)
+        if re.match(self.fileRegex,match.group(0)).group(1) != filename:
+            return None, 0, 0, '', '', '', ''
+
+        return match, line, col, error, warning, message, near
+
+    def cmd(self):
         gopath = self.get_view_settings().get('gopath')
         if gopath:
             if self.env:
@@ -35,7 +52,6 @@ class Gotype(Linter):
             else:
                 self.env = {'GOPATH': gopath}
 
-    def run(self, cmd, code):
-        """Copy package files to temp dir."""
-        files = [f for f in listdir(dirname(self.filename)) if f[-3:] == '.go']
-        return self.tmpdir(cmd, files, code)
+        """Generate the linter command string"""
+        return [self.executable_path, '-e', '-a', '-r='+path.basename(self.filename), '.']
+


### PR DESCRIPTION
I've submitted code for review to the golang tools repo that enables `gotype` to run on a live file. This change alters the linter to use this new functionality, removing the need to copy files to another directory. It also adds a filter to prevent errors in other files from being displayed in the current file.

This PR depends on [Change 4884](https://go-review.googlesource.com/#/c/4884/) and should not be merged until/unless this change is accepted to the main repo. The changes can be applied manually for those who wish to use this PR immediately.

I've submitted this PR to get feedback as python is not my best language.