### PR TITLE
Add vendor support

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,13 +10,11 @@
 
 """This module exports the Gotype plugin class."""
 
-from os import listdir
 from os.path import dirname
 from SublimeLinter.lint import Linter, util
 
 
 class Gotype(Linter):
-
     """Provides an interface to gotype."""
 
     syntax = ('go', 'gosublime-go')
@@ -36,9 +34,11 @@ class Gotype(Linter):
                 self.env = {'GOPATH': gopath}
 
     def cmd(self):
+        """Return the command line to run."""
         return [self.executable_path, "-e", "-a", dirname(self.filename)]
 
     def split_match(self, match):
+        """Process each match modifying or discarding it."""
         match, line, col, error, warning, message, near = super().split_match(match)
         if match.group("filename") != self.filename:
             return None, None, None, None, None, '', None

--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class Gotype(Linter):
 
     syntax = ('go', 'gosublime-go')
     executable = "gotype"
-    regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
+    regex = r'(?P<filename>^.+):(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     error_stream = util.STREAM_STDERR
 
     def __init__(self, view, syntax):
@@ -37,3 +37,9 @@ class Gotype(Linter):
 
     def cmd(self):
         return [self.executable_path, "-e", "-a", dirname(self.filename)]
+
+    def split_match(self, match):
+        match, line, col, error, warning, message, near = super().split_match(match)
+        if match.group("filename") != self.filename:
+            return None, None, None, None, None, '', None
+        return match, line, col, error, warning, message, near

--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Gotype(Linter):
     """Provides an interface to gotype."""
 
     syntax = ('go', 'gosublime-go')
-    cmd = ('gotype', '-e', '-a', '.')
+    executable = "gotype"
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     error_stream = util.STREAM_STDERR
 
@@ -35,7 +35,5 @@ class Gotype(Linter):
             else:
                 self.env = {'GOPATH': gopath}
 
-    def run(self, cmd, code):
-        """Copy package files to temp dir."""
-        files = [f for f in listdir(dirname(self.filename)) if f[-3:] == '.go']
-        return self.tmpdir(cmd, files, code)
+    def cmd(self):
+        return [self.executable_path, "-e", "-a", dirname(self.filename)]


### PR DESCRIPTION
Previously, vendor directories would be ignored because all files were copied to a temporary directory, so the vendor folder wasn't there anymore.

Fixed by avoiding copying to a temporary dir. At the same time, we need to make sure to always run gotype on a whole package, so we pass the directory name to it.